### PR TITLE
Update strawberryRunnerPostprocessorEntity.php

### DIFF
--- a/src/Entity/strawberryRunnerPostprocessorEntity.php
+++ b/src/Entity/strawberryRunnerPostprocessorEntity.php
@@ -21,7 +21,7 @@ use Drupal\Core\Config\Entity\ConfigEntityInterface;
  *       "delete" = "Drupal\strawberry_runners\Form\strawberryRunnerPostprocessorEntityDeleteForm"
  *     },
  *     "route_provider" = {
- *       "html" = "Drupal\strawberry_runners\strawberryRunnerPostprocessorEntityHtmlRouteProvider",
+ *       "html" = "Drupal\strawberry_runners\strawberryRunnerPostProcessorEntityHtmlRouteProvider",
  *     },
  *   },
  *   config_prefix = "strawberry_runners_postprocessor",


### PR DESCRIPTION
Fixes a strange thing where Annotation fails to be expanded into a fully loaded class because there is a LowerCase/UpperCase discrepancy, even if PHP is NOT case sensitive! This only happens on barebone Machines and does not fail on Docker? (Thanks @giancarlobi for detecting this! Good eyesight!)

This whole class/ anntotation will evolve now that we have Postprocessorts that generate Files, JSON and also INDEX elements. So stay tuned!