### PR TITLE
Move for now heavier stuff to a second not managed by CRON queue

### DIFF
--- a/src/Plugin/QueueWorker/AbstractPostProcessorQueueWorker.php
+++ b/src/Plugin/QueueWorker/AbstractPostProcessorQueueWorker.php
@@ -243,15 +243,12 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
     $tobechained = FALSE;
     error_log(print_r($enabled_processor_output_types, true));
     if (array_key_exists('searchapi', $enabled_processor_output_types) && $enabled_processor_output_types['searchapi'] === 'searchapi') {
-      error_log("processor says this goes into Solr");
       $tobeindexed = TRUE;
     }
     if (array_key_exists('file', $enabled_processor_output_types) && $enabled_processor_output_types['file'] === 'file') {
-      error_log("processor says this goes into Solr");
       $tobeupdated = TRUE;
     }
     if (array_key_exists('plugin', $enabled_processor_output_types) && $enabled_processor_output_types['plugin'] === 'plugin') {
-      error_log("processor says this goes into Solr");
       $tobechained = TRUE;
     }
 
@@ -395,7 +392,7 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
               $childdata->{$input_argument} = $value;
               error_log("should add to queue {$childdata->plugin_config_entity_id}");
               error_log(var_export($childdata, TRUE));
-              Drupal::queue('strawberryrunners_process_index')
+              Drupal::queue('strawberryrunners_process_background')
                 ->createItem($childdata);
             }
           }

--- a/src/Plugin/QueueWorker/backgroundPostProcessorQueueWorker.php
+++ b/src/Plugin/QueueWorker/backgroundPostProcessorQueueWorker.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 9/4/19
+ * Time: 4:19 PM
+ */
+
+namespace Drupal\strawberry_runners\Plugin\QueueWorker;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\TranslatableInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
+use Drupal\Core\StreamWrapper\StreamWrapperInterface;
+use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
+use Drupal\file\FileInterface;
+use Drupal\search_api\Query\QueryInterface;
+use Drupal\strawberry_runners\Plugin\StrawberryRunnersPostProcessorPluginInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\strawberry_runners\Plugin\StrawberryRunnersPostProcessorPluginManager;
+use Drupal\strawberryfield\Plugin\search_api\datasource\StrawberryfieldFlavorDatasource;
+use Drupal\search_api\ParseMode\ParseModePluginManager;
+
+
+/**
+ * Process the JSON payload provided by the webhook.
+ *
+ * @QueueWorker(
+ *   id = "strawberryrunners_process_background",
+ *   title = @Translation("Strawberry Runners Process to Index Queue Worker"),
+ * )
+ */
+class backgroundPostProcessorQueueWorker extends AbstractPostProcessorQueueWorker {
+}


### PR DESCRIPTION
@giancarlobi tiny change
This will be better later, each processor will be able to have a setting where you decide which queue. But for now "Second level" processors will go into trawberryrunners_process_backgro