### PR TITLE
Add space between words in MiniOCR

### DIFF
--- a/src/Plugin/StrawberryRunnersPostProcessor/OcrPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/OcrPostProcessor.php
@@ -474,7 +474,7 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
         $miniocr->startElement("b");
         $page->registerXPathNamespace('ns', 'http://www.w3.org/1999/xhtml');
         foreach ($page->xpath('.//ns:span[@class="ocr_line"]') as $line) {
-          $notFirstWord = 0;
+          $notFirstWord = FALSE;
           $miniocr->startElement("l");
           foreach ($line->children() as $word) {
             $wcoos = explode(" ", $word['title']);
@@ -491,7 +491,7 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
               if ($notFirstWord) {
                 $miniocr->text(' ');
               }
-              $notFirstWord = 1;
+              $notFirstWord = TRUE;
               $miniocr->startElement("w");
               $miniocr->writeAttribute("x", ltrim($l, '0') . ' ' . ltrim($t, 0) . ' ' . ltrim($w, 0) . ' ' . ltrim($h, 0));
               $miniocr->text($text);

--- a/src/Plugin/StrawberryRunnersPostProcessor/OcrPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/OcrPostProcessor.php
@@ -474,6 +474,7 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
         $miniocr->startElement("b");
         $page->registerXPathNamespace('ns', 'http://www.w3.org/1999/xhtml');
         foreach ($page->xpath('.//ns:span[@class="ocr_line"]') as $line) {
+          $notFirstWord = 0;
           $miniocr->startElement("l");
           foreach ($line->children() as $word) {
             $wcoos = explode(" ", $word['title']);
@@ -487,6 +488,10 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
               $w = round((($x1 - $x0) / $pwidth), 3);
               $h = round((($y1 - $y0) / $pheight), 3);
               $text = (string) $word;
+              if ($notFirstWord) {
+                $miniocr->text(' ');
+              }
+              $notFirstWord = 1;
               $miniocr->startElement("w");
               $miniocr->writeAttribute("x", ltrim($l, '0') . ' ' . ltrim($t, 0) . ' ' . ltrim($w, 0) . ' ' . ltrim($h, 0));
               $miniocr->text($text);


### PR DESCRIPTION
We need to add space between words in MiniOCR output to be compliant with new release of Solr plugin highlighting 0.6.0.
This is  a simple way to make this working, probably we can do it better to reflect input hOCR but that needs a whole function rebuild.