### PR TITLE
Solve Tesseract Alto Page ID

### DIFF
--- a/src/Plugin/StrawberryRunnersPostProcessor/OcrPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/OcrPostProcessor.php
@@ -417,13 +417,14 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
           }
 
           $miniocr = $this->ALTOtoMiniOCR($proc_output, $sequence_number);
+          $alto_with_pageid = $this->addPageIdToALTO($proc_output, $sequence_number);
           $output = new \stdClass();
 
           //$output->searchapi['fulltext'] = $miniocr;
-          $output->searchapi['fulltext'] = $proc_output;
+          $output->searchapi['fulltext'] = $alto_with_pageid;
 
           //$output->plugin = $miniocr;
-          $output->plugin = $proc_output;
+          $output->plugin = $alto_with_pageid;
 
           $io->output = $output;
         }
@@ -712,6 +713,17 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
     return $fulltext;
   }
 
+  protected function addPageIdToALTO($output, $pageid) {
+    $document = new \DOMDocument();
+    $document->loadXml($output);
+    $pageNodes = $document->getElementsByTagName( "Page" );
+    foreach ($pageNodes as $pageNode) {
+      $pageNode->setAttribute("ID", "Page".$pageid);
+    }
+    $newalto = $document->saveXml();
+    unset($document);
+    return $newalto;
+  }
 
 
   /**


### PR DESCRIPTION
Tesseract ALTO output has Page ID attribute = page_0 but we need ID = PageNumber, without this IAB search returns always page 0 as results of search.